### PR TITLE
Add rate limiting with express-rate-limit middleware (100 requests/15min, logging)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.5.0",
     "multer": "^1.4.5-lts.1",
     "uuid": "^11.0.5",
     "viem": "^2.21.42"

--- a/rate-limiting-middleware.js
+++ b/rate-limiting-middleware.js
@@ -1,0 +1,17 @@
+const rateLimit = require('express-rate-limit');
+const logger = require('./logger');
+
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  message: "Too many requests from this IP, please try again later.",
+  statusCode: 429,
+  onLimit: (req, res) => {
+    logger.error(req.ip, 'Rate limit exceeded', {
+      path: req.path,
+      method: req.method
+    });
+  }
+});
+
+module.exports = apiLimiter;

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const path = require("path");
 const os = require("os");
 const dotenv = require("dotenv");
 const cors = require("cors");
+const apiLimiter = require("./rate-limiting-middleware");
 
 dotenv.config();
 
@@ -22,6 +23,9 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
+
+// Rate limiter middleware
+app.use(apiLimiter);
 
 // Middleware to parse JSON bodies
 app.use(express.json());


### PR DESCRIPTION
Fixes #11 

Implemented rate limiting using express-rate-limit middleware. Added 100 requests per 15 minutes limit after that they will receive a message "Too many requests from this IP, please try again later.".