### PR TITLE
Add rate limiting with express-rate-limit middleware (100 requests/15…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
     "viem": "^2.21.42",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/rate-limiting-middleware.js
+++ b/rate-limiting-middleware.js
@@ -1,0 +1,17 @@
+const rateLimit = require('express-rate-limit');
+const logger = require('./logger');
+
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  message: "Too many requests from this IP, please try again later.",
+  statusCode: 429,
+  onLimit: (req, res) => {
+    logger.error(req.ip, 'Rate limit exceeded', {
+      path: req.path,
+      method: req.method
+    });
+  }
+});
+
+module.exports = apiLimiter;

--- a/server.js
+++ b/server.js
@@ -26,6 +26,9 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 
+// Rate limiter middleware
+app.use(apiLimiter);
+
 // Middleware to parse JSON bodies
 app.use(express.json());
 


### PR DESCRIPTION
Fixes https://github.com/akave-ai/akavelink/issues/11

Implemented rate limiting using express-rate-limit middleware. Added 100 requests per 15 minutes limit after that they will receive a message "Too many requests from this IP, please try again later.".

This new PR is raised due to changes requested in comments of https://github.com/akave-ai/akavelink/pull/36.